### PR TITLE
Remove breaking then()

### DIFF
--- a/app/services/csrf.js
+++ b/app/services/csrf.js
@@ -31,11 +31,10 @@ export default Ember.Object.extend({
     return this.get('data');
   },
   fetchToken: function() {
-    var promise;
     var _this = this;
     var token = Ember.$('meta[name="csrf-token"]').attr('content') || '';
 
-    return Ember.RSVP.resolve().promise.then(function() {
+    return Ember.RSVP.resolve().then(function() {
       return _this.setData({'authenticity_token': token });
     });
   }


### PR DESCRIPTION
Solves this issue when using rails-csrf with ember v1.11.0-beta.4

```
Uncaught TypeError: Cannot read property 'then' of undefined   csrf.js:39
fetchToken
```
